### PR TITLE
feat: 카카오 로그인 API 구현 (#1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,9 @@
-node_modules
+# 패키지 매니저
+node_modules/
+**/node_modules/
+
+# 환경 파일
 .env
+.env.*
+**/.env
+**/.env.*

--- a/app.js
+++ b/app.js
@@ -1,25 +1,22 @@
-import env from "./config/env.js";
 import express from "express";
-import mongoose from "mongoose";
 import cors from "cors";
-import uploadRouter from "./routes/upload.js";
+import uploadRouter from "./routes/s3Upload.js";
+import cookieParser from "cookie-parser";
+import authRoutes from "./routes/auth.js";
+import userRoutes from "./routes/user.js";
+import errorHandler from "./middlewares/errorHandler.js";
 
 const app = express();
 
-app.use(cors());
+app.use(cors({ origin: "http://localhost:5173", credentials: true }));
 app.use(express.json());
+app.use(cookieParser());
+
 app.use("/api", uploadRouter);
 
-mongoose
-  .connect(env.MONGODB_Atlas_URI)
-  .then(() => {
-    console.log("✅ MongoDB Atlas 연결 성공");
-  })
-  .catch((err) => {
-    console.error("❌ MongoDB 연결 에러:", err);
-  });
+app.use("/api/auth", authRoutes);
+app.use("/api/users", userRoutes);
 
-const PORT = env.PORT || 8000;
-app.listen(PORT, () => {
-  console.log(`🚀 서버 실행 중: http://localhost:${PORT}`);
-});
+app.use(errorHandler);
+
+export default app;

--- a/app.js
+++ b/app.js
@@ -8,7 +8,12 @@ import errorHandler from "./middlewares/errorHandler.js";
 
 const app = express();
 
-app.use(cors({ origin: "http://localhost:5173", credentials: true }));
+app.use(cors({
+  origin: true,
+  credentials: true,
+  allowedHeaders: ["Content-Type", "Authorization"],
+}));
+
 app.use(express.json());
 app.use(cookieParser());
 

--- a/config/env.js
+++ b/config/env.js
@@ -4,10 +4,15 @@ dotenv.config();
 export default {
   PORT: process.env.PORT || 8000,
 
-  MONGODB_Atlas_URI: process.env.MONGODB_Atlas_URI,
+  MONGODB_URL: process.env.MONGODB_URL,
 
   AWS_ACCESS_KEY_ID: process.env.AWS_ACCESS_KEY_ID,
   AWS_SECRET_ACCESS_KEY: process.env.AWS_SECRET_ACCESS_KEY,
   AWS_REGION: process.env.AWS_REGION,
   S3_BUCKET_NAME: process.env.S3_BUCKET_NAME,
+
+  JWT_SECRET: process.env.JWT_SECRET,
+
+  KAKAO_REST_API_KEY: process.env.KAKAO_REST_API_KEY,
+  KAKAO_REDIRECT_URI: process.env.KAKAO_REDIRECT_URI,
 };

--- a/controllers/kakaoAuthController.js
+++ b/controllers/kakaoAuthController.js
@@ -1,0 +1,122 @@
+import env from "../config/env.js";
+import jwt from "jsonwebtoken";
+import { v4 as uuidv4 } from "uuid";
+import User from "../models/User.js";
+
+const JWT_SECRET = env.JWT_SECRET;
+const JWT_EXPIRES_IN = "1h";
+
+export const kakaoLogin = async (req, res, next) => {
+  try {
+    const { code } = req.body;
+    if (!code) {
+      const err = new Error("카카오 인가 코드가 없습니다.");
+      err.status = 400;
+
+      return next(err);
+    }
+
+    const tokenRes = await fetch("https://kauth.kakao.com/oauth/token", {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        grant_type: "authorization_code",
+        client_id: env.KAKAO_REST_API_KEY,
+        redirect_uri: env.KAKAO_REDIRECT_URI,
+        code,
+      }),
+    });
+
+    const tokenData = await tokenRes.json();
+    const { access_token, refresh_token } = tokenData;
+    if (!access_token) {
+      const err = new Error("카카오 로그인 인증에 실패했습니다.");
+      err.status = 401;
+
+      return next(err);
+    }
+
+    const userRes = await fetch("https://kapi.kakao.com/v2/user/me", {
+      headers: { Authorization: `Bearer ${access_token}` },
+    });
+    const userData = await userRes.json();
+
+    const kakaoId = userData.id?.toString();
+    const nickname = userData.properties?.nickname || `User_${kakaoId}`;
+    const profileImage = userData.properties?.profile_image || null;
+
+    let user = await User.findOne({ kakaoId });
+    if (!user) {
+      user = await User.create({
+        userId: uuidv4(),
+        kakaoId,
+        nickname,
+        profileImage,
+        refreshToken: refresh_token,
+      });
+    } else {
+      user.refreshToken = refresh_token;
+      await user.save();
+    }
+
+    const accessToken = jwt.sign(
+      { userId: user.userId, kakaoId: user.kakaoId },
+      JWT_SECRET,
+      { expiresIn: JWT_EXPIRES_IN },
+    );
+
+    res.cookie("refreshToken", refresh_token, {
+      httpOnly: true,
+      secure: env.NODE_ENV === "production", // 배포 시 true
+      sameSite: "Lax",
+      path: "/",
+    });
+
+    res.status(200).json({
+      success: true,
+      message: "로그인 성공 및 회원가입이 완료되었습니다.",
+      token: accessToken,
+      user: {
+        userId: user.userId,
+        nickname: user.nickname,
+        profileImage: user.profileImage,
+        highlightColor: user.highlightColor,
+      },
+    });
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const refreshToken = async (req, res, next) => {
+  try {
+    const refreshToken = req.cookies.refreshToken;
+    if (!refreshToken) {
+      const err = new Error("유효하지 않거나 만료된 토큰입니다.");
+      err.status = 401;
+
+      return next(err);
+    }
+
+    const user = await User.findOne({ refreshToken });
+    if (!user) {
+      const err = new Error("유효하지 않거나 만료된 토큰입니다.");
+      err.status = 401;
+
+      return next(err);
+    }
+
+    const newAccessToken = jwt.sign(
+      { userId: user.userId, kakaoId: user.kakaoId },
+      JWT_SECRET,
+      { expiresIn: JWT_EXPIRES_IN },
+    );
+
+    res.status(200).json({
+      success: true,
+      accessToken: newAccessToken,
+    });
+  } catch (err) {
+    next(err);
+  }
+};

--- a/controllers/s3UploadController.js
+++ b/controllers/s3UploadController.js
@@ -1,0 +1,10 @@
+export const uploadImage = (req, res) => {
+  if (!req.file) {
+    return res.status(400).json({ message: "파일이 업로드되지 않았습니다." });
+  }
+
+  res.status(200).json({
+    message: "파일 업로드가 완료되었습니다.",
+    imageUrl: req.file.location,
+  });
+};

--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -1,0 +1,27 @@
+import User from "../models/User.js";
+
+export const getUserMe = async (req, res, next) => {
+  try {
+    const { userId } = req.user;
+
+    const user = await User.findOne({ userId });
+
+    if (!user) {
+      const err = new Error("사용자 정보를 찾을 수 없습니다.");
+      err.status = 404;
+      return next(err);
+    }
+
+    res.status(200).json({
+      message: "OK",
+      user: {
+        userId: user.userId,
+        nickname: user.nickname,
+        profileImage: user.profileImage,
+        highlightColor: user.highlightColor,
+      },
+    });
+  } catch (err) {
+    next(err);
+  }
+};

--- a/middlewares/errorHandler.js
+++ b/middlewares/errorHandler.js
@@ -1,0 +1,7 @@
+export default function errorHandler(err, req, res, next) {
+  const status = err.status || 500;
+  res.status(status).json({
+    success: false,
+    message: err.message || "서버 오류가 발생했습니다.",
+  });
+}

--- a/middlewares/verifyToken.js
+++ b/middlewares/verifyToken.js
@@ -1,0 +1,27 @@
+import env from "../config/env.js";
+import jwt from "jsonwebtoken";
+
+const JWT_SECRET = env.JWT_SECRET;
+
+export const verifyToken = (req, res, next) => {
+  const authHeader = req.headers.authorization;
+
+  if (!authHeader || !authHeader.startsWith("Bearer ")) {
+    const err = new Error("인증 정보가 유효하지 않습니다.");
+    err.status = 401;
+
+    return next(err);
+  }
+
+  const token = authHeader.split(" ")[1];
+
+  try {
+    const decoded = jwt.verify(token, JWT_SECRET);
+    req.user = decoded;
+    next();
+  } catch (err) {
+    err.status = 401;
+    err.message = "인증 정보가 유효하지 않습니다.";
+    next(err);
+  }
+};

--- a/models/User.js
+++ b/models/User.js
@@ -1,0 +1,32 @@
+import mongoose from "mongoose";
+
+const userSchema = new mongoose.Schema({
+  userId: {
+    type: String,
+    required: true,
+  },
+  kakaoId: {
+    type: String,
+    required: true,
+    unique: true,
+  },
+  nickname: {
+    type: String,
+    required: true,
+  },
+  profileImage: {
+    type: String,
+    default: null,
+  },
+  refreshToken: {
+    type: String,
+    default: null,
+  },
+  highlightColor: {
+    type: String,
+    default: "#ff0000",
+  },
+});
+
+const User = mongoose.model("User", userSchema);
+export default User;

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@aws-sdk/lib-storage": "^3.826.0",
         "aws-sdk": "^2.1692.0",
         "body-parser": "^2.2.0",
+        "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
         "dotenv": "^16.5.0",
         "express": "^5.1.0",
@@ -2480,6 +2481,25 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
+      "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
     },
     "node_modules/cookie-signature": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "index.js",
   "type": "module",
   "scripts": {
-    "dev": "nodemon app.js",
-    "start": "node app.js",
+    "dev": "nodemon server.js",
+    "start": "node server.js",
     "prepare": "husky install"
   },
   "author": "",
@@ -16,6 +16,7 @@
     "@aws-sdk/lib-storage": "^3.826.0",
     "aws-sdk": "^2.1692.0",
     "body-parser": "^2.2.0",
+    "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
     "dotenv": "^16.5.0",
     "express": "^5.1.0",

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -1,0 +1,12 @@
+import express from "express";
+import {
+  kakaoLogin,
+  refreshToken,
+} from "../controllers/kakaoAuthController.js";
+
+const router = express.Router();
+
+router.post("/kakao/login", kakaoLogin);
+router.post("/kakao/refresh", refreshToken);
+
+export default router;

--- a/routes/s3Upload.js
+++ b/routes/s3Upload.js
@@ -1,0 +1,9 @@
+import express from "express";
+import upload from "../config/multer.js";
+import { uploadImage } from "../controllers/s3UploadController.js";
+
+const router = express.Router();
+
+router.post("/upload", upload.single("image"), uploadImage);
+
+export default router;

--- a/routes/user.js
+++ b/routes/user.js
@@ -1,0 +1,9 @@
+import express from "express";
+import { getUserMe } from "../controllers/userController.js";
+import { verifyToken } from "../middlewares/verifyToken.js";
+
+const router = express.Router();
+
+router.get("/me", verifyToken, getUserMe);
+
+export default router;

--- a/server.js
+++ b/server.js
@@ -1,0 +1,17 @@
+import env from "./config/env.js";
+import mongoose from "mongoose";
+import app from "./app.js";
+
+mongoose
+  .connect(env.MONGODB_URL)
+  .then(() => {
+    console.log("MongoDB Atlas 연결 성공");
+  })
+  .catch((err) => {
+    console.error("MongoDB 연결 에러:", err);
+  });
+
+const PORT = env.PORT || 8000;
+app.listen(PORT, () => {
+  console.log(`서버 실행 중: http://localhost:${PORT}`);
+});


### PR DESCRIPTION
## #️⃣ Issue Number #01

## 📝 세부 내용

-  카카오 로그인 인증 기능을 구현했습니다.  
-  인가 코드를 받아 accessToken과 refreshToken을 발급받고, accessToken은 클라이언트 로컬 스토리지에 저장되며, refreshToken은 DB에     저장하고 HttpOnly 쿠키로 전달합니다.
- 카카오 로그인 시 사용자 정보를 조회하고, 자체 DB에 사용자 정보를 저장하도록 처리했습니다.  
  최초 로그인인 경우에는 회원가입까지 자동으로 완료됩니다.
- 전체 인증 흐름은 JWT 기반으로 구성되어 있으며, 추후 accessToken 만료 시 refreshToken으로 accessToken을 재발급할 수 있도록 `/kakao/refresh` API도 구현했습니다.

## 💬 리뷰 요청 사항

- 카카오 로그인 흐름이 보안적으로 적절하게 구성되었는지 확인 부탁드립니다.
- 기능별로 디렉토리를 나눈 구조 괜찮은지 검토 부탁드립니다.

## ✅ 체크리스트

- [x] 커밋 메시지 컨벤션을 지켰습니다 (`feat:`, `fix:`, `chore:` 등).
- [x] 관련 기능/버그에 대해 테스트를 완료했습니다.
- [x] 코드 스타일 가이드에 맞게 작성했습니다.
