### PR TITLE
feat: 매뉴얼 생성 API 구현 (#6)

### DIFF
--- a/app.js
+++ b/app.js
@@ -5,19 +5,23 @@ import cookieParser from "cookie-parser";
 import authRoutes from "./routes/auth.js";
 import userRoutes from "./routes/user.js";
 import errorHandler from "./middlewares/errorHandler.js";
+import manualRoutes from "./routes/manual.js";
 
 const app = express();
 
-app.use(cors({
-  origin: true,
-  credentials: true,
-  allowedHeaders: ["Content-Type", "Authorization"],
-}));
+app.use(
+  cors({
+    origin: true,
+    credentials: true,
+    allowedHeaders: ["Content-Type", "Authorization"],
+  }),
+);
 
 app.use(express.json());
 app.use(cookieParser());
 
 app.use("/api", uploadRouter);
+app.use("/api", manualRoutes);
 
 app.use("/api/auth", authRoutes);
 app.use("/api/users", userRoutes);

--- a/config/multer.js
+++ b/config/multer.js
@@ -8,6 +8,7 @@ const upload = multer({
   storage: multerS3({
     s3: s3,
     bucket: env.S3_BUCKET_NAME,
+    contentType: multerS3.AUTO_CONTENT_TYPE,
     key: (req, file, cb) => {
       const filename = `images/${uuidv4()}-${file.originalname}`;
       cb(null, filename);

--- a/controllers/createManual.js
+++ b/controllers/createManual.js
@@ -1,0 +1,61 @@
+import Manual from "../models/Manual.js";
+import { v4 as uuidv4 } from "uuid";
+import dayjs from "dayjs";
+
+export const createManual = async (req, res, next) => {
+  try {
+    const { userId } = req.user;
+
+    if (!req.files || req.files.length === 0) {
+      const err = new Error("파일이 업로드되지 않았습니다.");
+      err.status = 400;
+
+      return next(err);
+    }
+
+    let texts = req.body.text;
+    if (!texts) {
+      const err = new Error("단계별 안내 텍스트가 비어 있습니다.");
+      err.status = 400;
+
+      return next(err);
+    }
+    if (!Array.isArray(texts)) texts = [texts];
+
+    const today = dayjs().format("YYYYMMDD");
+    const existingManuals = await Manual.find({
+      userId,
+      name: new RegExp(`^${today}`),
+    }).sort({ name: 1 });
+    const name =
+      existingManuals.length > 0 ? `${today}-${existingManuals.length}` : today;
+
+    const steps = req.files.map((file, index) => ({
+      imageId: `img_${(index + 1).toString().padStart(3, "0")}`,
+      text: texts[index],
+      url: file.location,
+    }));
+
+    const manualId = `mnl_${uuidv4().slice(0, 8)}`;
+
+    const manual = await Manual.create({
+      manualId,
+      userId,
+      name,
+      steps,
+    });
+
+    res.status(201).json({
+      success: true,
+      data: {
+        manualId: manual.manualId,
+        name: manual.name,
+        imageCount: steps.length,
+        steps: manual.steps,
+        createdAt: manual.createdAt,
+      },
+    });
+  } catch (err) {
+    next(err);
+  }
+};

--- a/models/Manual.js
+++ b/models/Manual.js
@@ -1,0 +1,59 @@
+import mongoose from "mongoose";
+
+const stepSchema = new mongoose.Schema(
+  {
+    imageId: {
+      type: String,
+      required: true,
+    },
+    text: {
+      type: String,
+      required: true,
+    },
+    url: {
+      type: String,
+      required: true,
+    },
+  },
+  {
+    _id: false,
+  },
+);
+
+const manualSchema = new mongoose.Schema(
+  {
+    manualId: {
+      type: String,
+      required: true,
+      unique: true,
+      index: true,
+    },
+    userId: {
+      type: String,
+      required: true,
+    },
+    name: {
+      type: String,
+      required: true,
+    },
+    steps: [stepSchema],
+    sharedToken: {
+      type: String,
+      default: null,
+    },
+    sharedAt: {
+      type: Date,
+      default: null,
+    },
+    shareUrl: {
+      type: String,
+      default: null,
+    },
+  },
+  {
+    timestamps: true,
+  },
+);
+
+const Manual = mongoose.model("Manual", manualSchema);
+export default Manual;

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "body-parser": "^2.2.0",
         "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
+        "dayjs": "^1.11.13",
         "dotenv": "^16.5.0",
         "express": "^5.1.0",
         "jsonwebtoken": "^9.0.2",
@@ -2537,6 +2538,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
+      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "body-parser": "^2.2.0",
     "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
+    "dayjs": "^1.11.13",
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
     "jsonwebtoken": "^9.0.2",

--- a/routes/manual.js
+++ b/routes/manual.js
@@ -1,0 +1,10 @@
+import express from "express";
+import { createManual } from "../controllers/createManual.js";
+import upload from "../config/multer.js";
+import { verifyToken } from "../middlewares/verifyToken.js";
+
+const router = express.Router();
+
+router.post("/manual", verifyToken, upload.array("image"), createManual);
+
+export default router;


### PR DESCRIPTION
## #️⃣ Issue Number #06

## 📝 세부 내용

- 인증된 사용자가 이미지와 텍스트를 업로드하여 매뉴얼을 생성할 수 있도록 API를 구현했습니다.

- 업로드된 파일은 S3에 저장되고, 단계별 설명(steps)과 함께 MongoDB에 저장됩니다.

- 매뉴얼명은 당일 날짜 기반으로 자동 생성되며, 중복 시 숫자 접미사가 추가됩니다. (20250611, 20250611-1 등)

## 💬 리뷰 요청 사항

- steps 배열 생성 시 텍스트와 이미지 순서 매칭이 정확하게 이뤄지는지 확인 부탁드립니다.

- 매뉴얼 이름이 날짜 기반(YYYYMMDD, YYYYMMDD-1...)으로 중복 없이 잘 생성되는지 로직 확인 부탁드립니다.

- 변수명이 이해하기 쉬운 방향으로 개선될 수 있다면 피드백 부탁드립니다.

## ✅ 체크리스트

- [x] 커밋 메시지 컨벤션을 지켰습니다 (`feat:`, `fix:`, `chore:` 등).
- [x] 관련 기능/버그에 대해 테스트를 완료했습니다.
- [x] 코드 스타일 가이드에 맞게 작성했습니다.
