### PR TITLE
feat: 매뉴얼 제목 수정 API 구현 (#8)

### DIFF
--- a/controllers/updateManualName.js
+++ b/controllers/updateManualName.js
@@ -1,0 +1,36 @@
+import Manual from "../models/Manual.js";
+
+export const updateManualName = async (req, res, next) => {
+  try {
+    const { manualId } = req.params;
+    const { name } = req.body;
+
+    if (!name) {
+      const err = new Error("수정할 제목이 없습니다.");
+      err.status = 400;
+
+      return next(err);
+    }
+
+    const manual = await Manual.findOneAndUpdate(
+      { manualId },
+      { name },
+      { new: true },
+    );
+
+    if (!manual) {
+      const err = new Error("해당 manualId에 대한 매뉴얼이 존재하지 않습니다.");
+      err.status = 404;
+
+      return next(err);
+    }
+
+    res.json({
+      success: true,
+      manualId: manual.manualId,
+      name: manual.name,
+    });
+  } catch (err) {
+    next(err);
+  }
+};

--- a/routes/manual.js
+++ b/routes/manual.js
@@ -1,10 +1,12 @@
 import express from "express";
 import { createManual } from "../controllers/createManual.js";
+import { updateManualName } from "../controllers/updateManualName.js";
 import upload from "../config/multer.js";
 import { verifyToken } from "../middlewares/verifyToken.js";
 
 const router = express.Router();
 
 router.post("/manual", verifyToken, upload.array("image"), createManual);
+router.patch("/manual/:manualId", updateManualName);
 
 export default router;


### PR DESCRIPTION
## #️⃣ Issue Number #08

## 📝 세부 내용

- 사용자가 매뉴얼 생성 후 제목을 자유롭게 수정할 수 있도록 기능을 추가했습니다.
- 매뉴얼 제목 수정 API (`PATCH /api/manual/:manualId`)를 추가했습니다.
- manualId로 매뉴얼을 찾아 name 필드만 업데이트하는 기능을 구현했습니다.

## 💬 리뷰 요청 사항

- 컨트롤러 로직을 findOneAndUpdate로 간결하게 처리했는데, 구조나 에러 처리 방식에 개선할 부분이 있을지 확인 부탁드립니다.

## ✅ 체크리스트

- [x] 커밋 메시지 컨벤션을 지켰습니다 (`feat:`, `fix:`, `chore:` 등).
- [x] 관련 기능/버그에 대해 테스트를 완료했습니다.
- [x] 코드 스타일 가이드에 맞게 작성했습니다.
