### PR TITLE
feat: 매뉴얼 삭제 API 구현 (#10)

### DIFF
--- a/controllers/deleteManual.js
+++ b/controllers/deleteManual.js
@@ -4,7 +4,7 @@ export const deleteManual = async (req, res, next) => {
   try {
     const { manualId } = req.params;
 
-    const manual = await Manual.findOneAndDelete({ manualId });
+    const manual = await Manual.findOne({ manualId });
 
     if (!manual) {
       const err = new Error("해당 매뉴얼을 찾을 수 없습니다.");

--- a/controllers/deleteManual.js
+++ b/controllers/deleteManual.js
@@ -1,0 +1,26 @@
+import Manual from "../models/Manual.js";
+
+export const deleteManual = async (req, res, next) => {
+  try {
+    const { manualId } = req.params;
+
+    const manual = await Manual.findOneAndDelete({ manualId });
+
+    if (!manual) {
+      const err = new Error("해당 매뉴얼을 찾을 수 없습니다.");
+      err.status = 404;
+
+      return next(err);
+    }
+
+    await Manual.deleteOne({ manualId });
+
+    res.json({
+      deleted: true,
+      manualId,
+      message: "해당 매뉴얼이 삭제되었습니다.",
+    });
+  } catch (err) {
+    next(err);
+  }
+};

--- a/controllers/updateManualName.js
+++ b/controllers/updateManualName.js
@@ -1,0 +1,36 @@
+import Manual from "../models/Manual.js";
+
+export const updateManualName = async (req, res, next) => {
+  try {
+    const { manualId } = req.params;
+    const { name } = req.body;
+
+    if (!name) {
+      const err = new Error("수정할 제목이 없습니다.");
+      err.status = 400;
+
+      return next(err);
+    }
+
+    const manual = await Manual.findOneAndUpdate(
+      { manualId },
+      { name },
+      { new: true },
+    );
+
+    if (!manual) {
+      const err = new Error("해당 manualId에 대한 매뉴얼이 존재하지 않습니다.");
+      err.status = 404;
+
+      return next(err);
+    }
+
+    res.json({
+      success: true,
+      manualId: manual.manualId,
+      name: manual.name,
+    });
+  } catch (err) {
+    next(err);
+  }
+};

--- a/routes/manual.js
+++ b/routes/manual.js
@@ -1,12 +1,14 @@
 import express from "express";
 import { createManual } from "../controllers/createManual.js";
-import { updateManualName } from "../controllers/updateManualName.js";
 import upload from "../config/multer.js";
+import { updateManualName } from "../controllers/updateManualName.js";
+import { deleteManual } from "../controllers/deleteManual.js";
 import { verifyToken } from "../middlewares/verifyToken.js";
 
 const router = express.Router();
 
 router.post("/manual", verifyToken, upload.array("image"), createManual);
 router.patch("/manual/:manualId", updateManualName);
+router.delete("/manual/:manualId", deleteManual);
 
 export default router;

--- a/routes/manual.js
+++ b/routes/manual.js
@@ -1,9 +1,9 @@
 import express from "express";
 import { createManual } from "../controllers/createManual.js";
-import upload from "../config/multer.js";
 import { updateManualName } from "../controllers/updateManualName.js";
-import { deleteManual } from "../controllers/deleteManual.js";
+import upload from "../config/multer.js";
 import { verifyToken } from "../middlewares/verifyToken.js";
+import { deleteManual } from "../controllers/deleteManual.js";
 
 const router = express.Router();
 

--- a/routes/manual.js
+++ b/routes/manual.js
@@ -1,10 +1,12 @@
 import express from "express";
 import { createManual } from "../controllers/createManual.js";
+import { updateManualName } from "../controllers/updateManualName.js";
 import upload from "../config/multer.js";
 import { verifyToken } from "../middlewares/verifyToken.js";
 
 const router = express.Router();
 
 router.post("/manual", verifyToken, upload.array("image"), createManual);
+router.patch("/manual/:manualId", updateManualName);
 
 export default router;


### PR DESCRIPTION
## #️⃣ Issue Number #10

## 📝 세부 내용

- 사용자가 더 이상 필요 없는 매뉴얼을 삭제할 수 있도록 하기 위해 해당 기능을 추가했습니다.
- 매뉴얼 삭제 API (`DELETE /api/manual/:manualId`)를 추가했습니다.
- manualId로 매뉴얼을 찾아 삭제하는 기능을 구현했습니다.

## 💬 리뷰 요청 사항

- 삭제 성공 시 응답 구조 ("deleted", "manualId", "message")가 명확한지 확인 부탁드립니다.
- 매뉴얼 삭제 시 "findOne"으로 존재 여부를 먼저 확인한 방식이 적절한지 검토 부탁드립니다.

## ✅ 체크리스트

- [x] 커밋 메시지 컨벤션을 지켰습니다 (`feat:`, `fix:`, `chore:` 등).
- [x] 관련 기능/버그에 대해 테스트를 완료했습니다.
- [x] 코드 스타일 가이드에 맞게 작성했습니다.
