### PR TITLE
feat: 로그아웃 API 구현 (#12)

### DIFF
--- a/controllers/kakaoAuthController.js
+++ b/controllers/kakaoAuthController.js
@@ -45,6 +45,8 @@ export const kakaoLogin = async (req, res, next) => {
     const nickname = userData.properties?.nickname || `User_${kakaoId}`;
     const profileImage = userData.properties?.profile_image || null;
 
+    const refreshToken = uuidv4();
+
     let user = await User.findOne({ kakaoId });
     if (!user) {
       user = await User.create({
@@ -52,30 +54,35 @@ export const kakaoLogin = async (req, res, next) => {
         kakaoId,
         nickname,
         profileImage,
-        refreshToken: refresh_token,
+        kakaoAccessToken: access_token,
+        kakaoRefreshToken: refresh_token,
+        refreshToken: refreshToken,
       });
     } else {
-      user.refreshToken = refresh_token;
+      user.refreshToken = refreshToken;
+      user.kakaoAccessToken = access_token;
+      user.kakaoRefreshToken = refresh_token;
       await user.save();
     }
 
-    const accessToken = jwt.sign(
+    const jwtAccessToken = jwt.sign(
       { userId: user.userId, kakaoId: user.kakaoId },
       JWT_SECRET,
       { expiresIn: JWT_EXPIRES_IN },
     );
 
-    res.cookie("refreshToken", refresh_token, {
+    res.cookie("refreshToken", refreshToken, {
       httpOnly: true,
       secure: env.NODE_ENV === "production",
       sameSite: "Lax",
       path: "/",
+      maxAge: 14 * 24 * 60 * 60 * 1000,
     });
 
     res.status(200).json({
       success: true,
       message: "로그인 성공 및 회원가입이 완료되었습니다.",
-      token: accessToken,
+      token: jwtAccessToken,
       user: {
         userId: user.userId,
         nickname: user.nickname,

--- a/controllers/kakaoAuthController.js
+++ b/controllers/kakaoAuthController.js
@@ -127,3 +127,25 @@ export const refreshToken = async (req, res, next) => {
     next(err);
   }
 };
+
+export const kakaoLogout = async (req, res, next) => {
+  try {
+    const { userId } = req.user;
+
+    await User.updateOne({ userId }, { $unset: { refreshToken: "" }});
+
+    res.clearCookie("refreshToken", {
+      httpOnly: true,
+      secure: env.NODE_ENV === "production",
+      sameSite: "Lax",
+      path: "/",
+    });
+
+    res.json({
+      success: true,
+      message: "성공적으로 로그아웃되었습니다.",
+    });
+  } catch (err) {
+    next(err);
+  }
+};

--- a/models/User.js
+++ b/models/User.js
@@ -26,7 +26,7 @@ const userSchema = new mongoose.Schema({
     type: String,
     default: "#ff0000",
   },
-  jwtRefreshToken: {
+  refreshToken: {
     type: String,
     default: null,
   },

--- a/models/User.js
+++ b/models/User.js
@@ -26,6 +26,18 @@ const userSchema = new mongoose.Schema({
     type: String,
     default: "#ff0000",
   },
+  jwtRefreshToken: {
+    type: String,
+    default: null,
+  },
+  kakaoAccessToken: {
+    type: String,
+    default: null,
+  },
+  kakaoRefreshToken: {
+    type: String,
+    default: null,
+  },
 });
 
 const User = mongoose.model("User", userSchema);

--- a/models/User.js
+++ b/models/User.js
@@ -26,10 +26,6 @@ const userSchema = new mongoose.Schema({
     type: String,
     default: "#ff0000",
   },
-  refreshToken: {
-    type: String,
-    default: null,
-  },
   kakaoAccessToken: {
     type: String,
     default: null,

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -2,11 +2,14 @@ import express from "express";
 import {
   kakaoLogin,
   refreshToken,
+  kakaoLogout,
 } from "../controllers/kakaoAuthController.js";
+import { verifyToken } from "../middlewares/verifyToken.js";
 
 const router = express.Router();
 
 router.post("/kakao/login", kakaoLogin);
 router.post("/kakao/refresh", refreshToken);
+router.post("/kakao/logout", verifyToken, kakaoLogout);
 
 export default router;


### PR DESCRIPTION
## #️⃣ Issue Number #12>

## 📝 세부 내용

- 카카오 로그인 후 자동 로그인 상태를 유지하기 위한 서버 측 로그아웃 기능을 구현했습니다.
- 사용자가 로그아웃 시, 서버에 저장된 refreshToken 필드 제거 및 쿠키 삭제 처리를 하였습니다.
- 클라이언트에서 accessToken 헤더로 요청 시 로그아웃 가능하도록 구현했습니다.
- 카카오 로그인 후 JWT accessToken 발급 및 UUID 기반 refreshToken 생성 로직을 추가했습니다.
- UUID 기반 refreshToken은 서버에서 DB와 httpOnly 쿠키에 저장하고, JWT accessToken은 클라이언트 localStorage에 저장하도록 구현했습니다.
- 카카오 access_token / refresh_token를 함께 DB에 저장해, 이후 사용자 자동 로그인 및 카카오 API 호출 시 사용할 수 있도록 동작하도록 구현했습니다.

## 💬 리뷰 요청 사항

- 카카오 토큰을 DB에 함께 저장하는 방식과 로그아웃 시 처리 흐름이 자연스러운지 확인 부탁드립니다.
- JWT accessToken / refreshToken 저장 및 삭제 방식이 보안상 적절한지 확인 부탁드립니다.

## ✅ 체크리스트

- [x] 커밋 메시지 컨벤션을 지켰습니다 (`feat:`, `fix:`, `chore:` 등).
- [x] 관련 기능/버그에 대해 테스트를 완료했습니다.
- [x] 코드 스타일 가이드에 맞게 작성했습니다.
