### PR TITLE
feat: 회원탈퇴 API 구현 (#14)

### DIFF
--- a/config/env.js
+++ b/config/env.js
@@ -15,4 +15,6 @@ export default {
 
   KAKAO_REST_API_KEY: process.env.KAKAO_REST_API_KEY,
   KAKAO_REDIRECT_URI: process.env.KAKAO_REDIRECT_URI,
+
+  NODE_ENV: process.env.NODE_ENV,
 };

--- a/controllers/kakaoAuthController.js
+++ b/controllers/kakaoAuthController.js
@@ -45,6 +45,8 @@ export const kakaoLogin = async (req, res, next) => {
     const nickname = userData.properties?.nickname || `User_${kakaoId}`;
     const profileImage = userData.properties?.profile_image || null;
 
+    const refreshToken = uuidv4();
+
     let user = await User.findOne({ kakaoId });
     if (!user) {
       user = await User.create({
@@ -52,30 +54,35 @@ export const kakaoLogin = async (req, res, next) => {
         kakaoId,
         nickname,
         profileImage,
-        refreshToken: refresh_token,
+        kakaoAccessToken: access_token,
+        kakaoRefreshToken: refresh_token,
+        refreshToken: refreshToken,
       });
     } else {
-      user.refreshToken = refresh_token;
+      user.refreshToken = refreshToken;
+      user.kakaoAccessToken = access_token;
+      user.kakaoRefreshToken = refresh_token;
       await user.save();
     }
 
-    const accessToken = jwt.sign(
+    const jwtAccessToken = jwt.sign(
       { userId: user.userId, kakaoId: user.kakaoId },
       JWT_SECRET,
       { expiresIn: JWT_EXPIRES_IN },
     );
 
-    res.cookie("refreshToken", refresh_token, {
+    res.cookie("refreshToken", refreshToken, {
       httpOnly: true,
       secure: env.NODE_ENV === "production",
       sameSite: "Lax",
       path: "/",
+      maxAge: 14 * 24 * 60 * 60 * 1000,
     });
 
     res.status(200).json({
       success: true,
       message: "로그인 성공 및 회원가입이 완료되었습니다.",
-      token: accessToken,
+      token: jwtAccessToken,
       user: {
         userId: user.userId,
         nickname: user.nickname,

--- a/controllers/kakaoAuthController.js
+++ b/controllers/kakaoAuthController.js
@@ -127,3 +127,25 @@ export const refreshToken = async (req, res, next) => {
     next(err);
   }
 };
+
+export const kakaoLogout = async (req, res, next) => {
+  try {
+    const { userId } = req.user;
+
+    await User.updateOne({ userId }, { $unset: { refreshToken: "" }});
+
+    res.clearCookie("refreshToken", {
+      httpOnly: true,
+      secure: env.NODE_ENV === "production",
+      sameSite: "Lax",
+      path: "/",
+    });
+
+    res.json({
+      success: true,
+      message: "성공적으로 로그아웃되었습니다.",
+    });
+  } catch (err) {
+    next(err);
+  }
+};

--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -1,4 +1,5 @@
 import User from "../models/User.js";
+import env from "../config/env.js";
 
 export const getUserMe = async (req, res, next) => {
   try {
@@ -20,6 +21,34 @@ export const getUserMe = async (req, res, next) => {
         profileImage: user.profileImage,
         highlightColor: user.highlightColor,
       },
+    });
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const deleteUserMe = async (req, res, next) => {
+  try {
+    const { userId } = req.user;
+
+    const user = await User.findOneAndDelete({ userId });
+    if (!user) {
+      const err = new Error("사용자 정보를 찾을 수 없습니다.");
+      err.status = 404;
+
+      return next(err);
+    }
+
+    res.clearCookie("refreshToken", {
+      httpOnly: true,
+      secure: env.NODE_ENV === "production",
+      sameSite: "Lax",
+      path: "/",
+    });
+
+    res.json({
+      success: true,
+      message: "회원 탈퇴가 완료되었습니다."
     });
   } catch (err) {
     next(err);

--- a/models/User.js
+++ b/models/User.js
@@ -26,7 +26,7 @@ const userSchema = new mongoose.Schema({
     type: String,
     default: "#ff0000",
   },
-  jwtRefreshToken: {
+  refreshToken: {
     type: String,
     default: null,
   },

--- a/models/User.js
+++ b/models/User.js
@@ -26,6 +26,18 @@ const userSchema = new mongoose.Schema({
     type: String,
     default: "#ff0000",
   },
+  jwtRefreshToken: {
+    type: String,
+    default: null,
+  },
+  kakaoAccessToken: {
+    type: String,
+    default: null,
+  },
+  kakaoRefreshToken: {
+    type: String,
+    default: null,
+  },
 });
 
 const User = mongoose.model("User", userSchema);

--- a/models/User.js
+++ b/models/User.js
@@ -26,10 +26,6 @@ const userSchema = new mongoose.Schema({
     type: String,
     default: "#ff0000",
   },
-  refreshToken: {
-    type: String,
-    default: null,
-  },
   kakaoAccessToken: {
     type: String,
     default: null,

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -2,11 +2,14 @@ import express from "express";
 import {
   kakaoLogin,
   refreshToken,
+  kakaoLogout,
 } from "../controllers/kakaoAuthController.js";
+import { verifyToken } from "../middlewares/verifyToken.js";
 
 const router = express.Router();
 
 router.post("/kakao/login", kakaoLogin);
 router.post("/kakao/refresh", refreshToken);
+router.post("/kakao/logout", verifyToken, kakaoLogout);
 
 export default router;

--- a/routes/user.js
+++ b/routes/user.js
@@ -1,9 +1,10 @@
 import express from "express";
-import { getUserMe } from "../controllers/userController.js";
+import { getUserMe, deleteUserMe } from "../controllers/userController.js";
 import { verifyToken } from "../middlewares/verifyToken.js";
 
 const router = express.Router();
 
 router.get("/me", verifyToken, getUserMe);
+router.delete("/me", verifyToken, deleteUserMe);
 
 export default router;


### PR DESCRIPTION
## #️⃣ Issue Number #14

## 📝 세부 내용

- DELETE /api/users/me 라우터를 추가하였습니다.

- JWT 인증을 통해 사용자를 식별하고 DB에서 삭제합니다.

- 쿠키에 저장된 refreshToken도 함께 제거되도록 처리했습니다.

## 💬 리뷰 요청 사항

- 회원 탈퇴 시 refreshToken 쿠키와 DB 내 사용자 정보를 제거하는 흐름이 보안상 안전하고 일관적인지 확인 부탁드립니다.

## ✅ 체크리스트

- [x] 커밋 메시지 컨벤션을 지켰습니다 (`feat:`, `fix:`, `chore:` 등).
- [x] 관련 기능/버그에 대해 테스트를 완료했습니다.
- [x] 코드 스타일 가이드에 맞게 작성했습니다.
