### PR TITLE
feat: 사용자 표시 색상 수정 API 구현 (#16)

### DIFF
--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -54,3 +54,39 @@ export const deleteUserMe = async (req, res, next) => {
     next(err);
   }
 };
+
+export const updateHighlightColor = async (req, res, next) => {
+  try {
+    const { userId } = req.user;
+    const { highlightColor } = req.body;
+
+    if (!highlightColor || typeof highlightColor !== "string") {
+      const err = new Error("highlightColor 값이 유효하지 않습니다.");
+      err.status = 400;
+
+      return next(err);
+    }
+
+    const user = await User.findOneAndUpdate(
+      { userId },
+      { highlightColor },
+      { new: true },
+    )
+
+    if (!user) {
+      const err = new Error("사용자 정보를 찾을 수 없습니다.");
+      err.status = 404;
+
+      return next(err);
+    }
+
+    res.json({
+      success: true,
+      data: {
+        highlightColor: user.highlightColor,
+      },
+    });
+  } catch (err) {
+    next(err);
+  }
+};

--- a/routes/user.js
+++ b/routes/user.js
@@ -1,10 +1,15 @@
 import express from "express";
-import { getUserMe, deleteUserMe } from "../controllers/userController.js";
+import {
+  getUserMe,
+  deleteUserMe,
+  updateHighlightColor,
+} from "../controllers/userController.js";
 import { verifyToken } from "../middlewares/verifyToken.js";
 
 const router = express.Router();
 
 router.get("/me", verifyToken, getUserMe);
 router.delete("/me", verifyToken, deleteUserMe);
+router.patch("/me", verifyToken, updateHighlightColor);
 
 export default router;


### PR DESCRIPTION
## #️⃣ Issue Number #16

## 📝 세부 내용

- 사용자 표시 색상(highlightColor) 수정 API를 구현했습니다.

- 인증된 사용자가 PATCH /api/users/me 요청을 통해 highlightColor를 변경할 수 있습니다.

- 요청 본문에서 전달된 색상 값은 MongoDB에 저장되며, 성공 시 수정된 색상을 응답합니다.

## 💬 리뷰 요청 사항

- highlightColor 검증과 관련해, 현재는 문자열 타입만 확인하고 있는데 형식 검증이나 허용 범위 설정 등 다른 방식이 더 적절할지 의견 부탁드립니다.
- 현재 highlightColor 저장 방식이나 API 구조가 적절한지, 혹시 개선할 부분이 있다면 의견 부탁드립니다.

## ✅ 체크리스트

- [x] 커밋 메시지 컨벤션을 지켰습니다 (`feat:`, `fix:`, `chore:` 등).
- [x] 관련 기능/버그에 대해 테스트를 완료했습니다.
- [x] 코드 스타일 가이드에 맞게 작성했습니다.
