### PR TITLE
feat: 매뉴얼 이미지 텍스트 수정 API 구현 (#18)

### DIFF
--- a/controllers/createManual.js
+++ b/controllers/createManual.js
@@ -50,7 +50,7 @@ export const createManual = async (req, res, next) => {
       data: {
         manualId: manual.manualId,
         name: manual.name,
-        imageCount: steps.length,
+        imageCount: manual.steps.length,
         steps: manual.steps,
         createdAt: manual.createdAt,
       },

--- a/controllers/updateManualStepText.js
+++ b/controllers/updateManualStepText.js
@@ -1,0 +1,47 @@
+import Manual from "../models/Manual.js";
+
+export const updateStepText = async (req, res, next) => {
+  try {
+    const { manualId, imageId } = req.params;
+    const { text } = req.body;
+
+    if (!text || typeof text !== "string") {
+      const err = new Error("수정할 텍스트가 유효하지 않습니다.");
+      err.status = 400;
+
+      return next(err);
+    }
+
+    const manual = await Manual.findOne({ manualId });
+    if (!manual) {
+      const err = new Error("해당 manualId에 대한 매뉴얼이 존재하지 않습니다.");
+      err.status = 404;
+
+      return next(err);
+    }
+
+    const step = manual.steps.find((step) => step.imageId === imageId);
+    if (!step) {
+      const err = new Error("해당 imageId에 대한 이미지가 존재하지 않습니다.");
+      err.status = 404;
+
+      return next(err);
+    }
+
+    step.text = text;
+    await manual.save();
+
+    res.json({
+      success: true,
+      data: {
+        manualId: manual.manualId,
+        name: manual.name,
+        imageCount: manual.steps.length,
+        steps: manual.steps,
+        createdAt: manual.createdAt,
+      },
+    });
+  } catch (err) {
+    next(err);
+  }
+};

--- a/routes/manual.js
+++ b/routes/manual.js
@@ -4,11 +4,13 @@ import { updateManualName } from "../controllers/updateManualName.js";
 import upload from "../config/multer.js";
 import { verifyToken } from "../middlewares/verifyToken.js";
 import { deleteManual } from "../controllers/deleteManual.js";
+import { updateStepText } from "../controllers/updateManualStepText.js";
 
 const router = express.Router();
 
 router.post("/manual", verifyToken, upload.array("image"), createManual);
 router.patch("/manual/:manualId", updateManualName);
 router.delete("/manual/:manualId", deleteManual);
+router.patch("/manual/:manualId/images/:imageId", updateStepText);
 
 export default router;


### PR DESCRIPTION
## #️⃣ Issue Number #18

## 📝 세부 내용

- PATCH /api/manual/:manualId/images/:imageId 라우터를 추가하였습니다.
- 매뉴얼에서 특정 이미지(imageId)에 연결된 텍스트(text)를 수정할 수 있도록 기능을 구현했습니다.
- 요청된 manualId와 imageId를 기반으로 매뉴얼을 조회한 뒤, 해당 단계의 텍스트만 안전하게 수정되도록 처리했습니다.

## 💬 리뷰 요청 사항

- 텍스트 수정 후 매뉴얼 전체 데이터를 응답으로 보내고 있는데, 이 방식이 괜찮을지, 아니면 수정된 step만 선택적으로 보내는 게 나을지 의견 부탁드립니다.

## ✅ 체크리스트

- [x] 커밋 메시지 컨벤션을 지켰습니다 (`feat:`, `fix:`, `chore:` 등).
- [x] 관련 기능/버그에 대해 테스트를 완료했습니다.
- [x] 코드 스타일 가이드에 맞게 작성했습니다.
