### PR TITLE
feat: 매뉴얼 조회 API 구현 (#22)

### DIFF
--- a/controllers/getManual.js
+++ b/controllers/getManual.js
@@ -1,0 +1,29 @@
+import Manual from "../models/Manual.js";
+
+export const getManual = async (req, res, next) => {
+  try {
+    const { manualId } = req.params;
+
+    const manual = await Manual.findOne({ manualId });
+    if (!manual) {
+      const err = new Error("해당 manualId에 대한 매뉴얼이 존재하지 않습니다.");
+      err.status = 404;
+
+      return next(err);
+    }
+
+    res.json({
+      success: true,
+      message: "매뉴얼을 성공적으로 조회했습니다.",
+      data: {
+        manualId: manual.manualId,
+        name: manual.name,
+        imageCount: manual.steps.length,
+        steps: manual.steps,
+        createdAt: manual.createdAt,
+      },
+    });
+  } catch (err) {
+    next(err);
+  }
+}

--- a/routes/manual.js
+++ b/routes/manual.js
@@ -6,6 +6,7 @@ import { verifyToken } from "../middlewares/verifyToken.js";
 import { deleteManual } from "../controllers/deleteManual.js";
 import { updateStepText } from "../controllers/updateManualStepText.js";
 import { getManualList } from "../controllers/getManualList.js";
+import { getManual } from "../controllers/getManual.js";
 
 const router = express.Router();
 
@@ -14,5 +15,6 @@ router.patch("/manual/:manualId", updateManualName);
 router.delete("/manual/:manualId", deleteManual);
 router.patch("/manual/:manualId/images/:imageId", updateStepText);
 router.get("/manual_list", verifyToken, getManualList);
+router.get("/manual/:manualId", getManual);
 
 export default router;


### PR DESCRIPTION
## #️⃣ Issue Number #22

## 📝 세부 내용

- 사용자가 특정 매뉴얼을 조회할 수 있도록 GET /api/manual/:manualId API를 구현했습니다.
- manualId를 기반으로 매뉴얼 데이터를 불러옵니다.
- 매뉴얼이 존재하지 않는 경우 404 에러를 반환하도록 처리했습니다.

## ✅ 체크리스트

- [x] 커밋 메시지 컨벤션을 지켰습니다 (`feat:`, `fix:`, `chore:` 등).
- [x] 관련 기능/버그에 대해 테스트를 완료했습니다.
- [x] 코드 스타일 가이드에 맞게 작성했습니다.
