### PR TITLE
feat: login-page-connect(백엔드)구현 (#21)

### DIFF
--- a/controllers/kakaoRedirectLogin.js
+++ b/controllers/kakaoRedirectLogin.js
@@ -1,0 +1,82 @@
+import env from "../config/env.js";
+import jwt from "jsonwebtoken";
+import { v4 as uuidv4 } from "uuid";
+import User from "../models/User.js";
+
+const JWT_SECRET = env.JWT_SECRET;
+const JWT_EXPIRES_IN = "1h";
+
+export const kakaoRedirectLogin = async (req, res, next) => {
+  try {
+    const { code } = req.query;
+    if (!code) {
+      return res.status(400).send("인가 코드가 없습니다.");
+    }
+    const tokenRes = await fetch("https://kauth.kakao.com/oauth/token", {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        grant_type: "authorization_code",
+        client_id: env.KAKAO_REST_API_KEY,
+        redirect_uri: env.KAKAO_REDIRECT_URI,
+        code,
+      }),
+    });
+
+    const tokenData = await tokenRes.json();
+    const { access_token, refresh_token } = tokenData;
+    if (!access_token) {
+      return res.status(401).send("카카오 로그인 실패");
+    }
+
+    const userRes = await fetch("https://kapi.kakao.com/v2/user/me", {
+      headers: { Authorization: `Bearer ${access_token}` },
+    });
+    const userData = await userRes.json();
+
+    const kakaoId = userData.id?.toString();
+    const nickname = userData.properties?.nickname || `User_${kakaoId}`;
+    const profileImage = userData.properties?.profile_image || null;
+
+    const refreshToken = uuidv4();
+
+    let user = await User.findOne({ kakaoId });
+    if (!user) {
+      user = await User.create({
+        userId: uuidv4(),
+        kakaoId,
+        nickname,
+        profileImage,
+        kakaoAccessToken: access_token,
+        kakaoRefreshToken: refresh_token,
+        refreshToken: refreshToken,
+      });
+    } else {
+      user.refreshToken = refreshToken;
+      user.kakaoAccessToken = access_token;
+      user.kakaoRefreshToken = refresh_token;
+      await user.save();
+    }
+
+    const jwtAccessToken = jwt.sign(
+      { userId: user.userId, kakaoId: user.kakaoId },
+      JWT_SECRET,
+      { expiresIn: "1h" },
+    );
+    res.send(`
+    <html>
+      <body>
+        <script>
+          (function() {
+            const token = ${JSON.stringify(jwtAccessToken)};
+            window.opener.postMessage({ token }, "*");
+            window.close();
+          })();
+        </script>
+      </body>
+    </html>
+  `);
+  } catch (err) {
+    next(err);
+  }
+};

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -4,10 +4,14 @@ import {
   refreshToken,
   kakaoLogout,
 } from "../controllers/kakaoAuthController.js";
+
+import { kakaoRedirectLogin } from "../controllers/kakaoRedirectLogin.js";
+
 import { verifyToken } from "../middlewares/verifyToken.js";
 
 const router = express.Router();
 
+router.get("/kakao/callback", kakaoRedirectLogin);
 router.post("/kakao/login", kakaoLogin);
 router.post("/kakao/refresh", refreshToken);
 router.post("/kakao/logout", verifyToken, kakaoLogout);

--- a/server.js
+++ b/server.js
@@ -2,6 +2,10 @@ import env from "./config/env.js";
 import mongoose from "mongoose";
 import app from "./app.js";
 
+app.use((req, res, next) => {
+  next();
+});
+
 mongoose
   .connect(env.MONGODB_URL)
   .then(() => {


### PR DESCRIPTION
## #️⃣ Issue Number #21

## 📝 세부 내용

login 페이지의 버튼을 누르면 
팝업 페이지를 통해 로그인 절차를 진행하고  
카카오에서 인증을 받아 회원가입 및 로그인 처리를 하도록 합니다.

## 💬 리뷰 요청 사항
로그인이 정상적으로 이루어지는지 확인 부탁드립니다.

## ✅ 체크리스트

- [x] 커밋 메시지 컨벤션을 지켰습니다 (`feat:`, `fix:`, `chore:` 등).
- [x] 관련 기능/버그에 대해 테스트를 완료했습니다.
- [x] 코드 스타일 가이드에 맞게 작성했습니다.
