### PR TITLE
refactor: 매뉴얼 스키마 정리, 공용 유틸 함수 및 오류 메시지 상수화 (#24)

### DIFF
--- a/config/constants.js
+++ b/config/constants.js
@@ -1,0 +1,25 @@
+export const MESSAGES = {
+  SUCCESS: {
+    MANUAL_DELETE: "해당 매뉴얼이 삭제되었습니다.",
+    MANUAL_GET: "매뉴얼을 조회했습니다.",
+    AUTH_LOGIN: "로그인 성공 및 회원가입이 완료되었습니다.",
+    AUTH_LOGOUT: "성공적으로 로그아웃되었습니다.",
+    AUTH_DELETE: "회원 탈퇴가 완료되었습니다.",
+    IMAGE_UPLOAD: "이미지 업로드가 완료되었습니다.",
+  },
+  ERROR: {
+    FILE_REQUIRED: "파일이 업로드되지 않았습니다.",
+    STEP_TEXT_REQUIRED: "단계별 안내 텍스트가 비어 있습니다.",
+    MANUAL_NOT_FOUND: "해당 manualId에 대한 매뉴얼이 존재하지 않습니다.",
+    MANUAL_NAME_REQUIRED: "수정할 제목이 없습니다.",
+    STEP_TEXT_INVALID: "수정할 텍스트가 유효하지 않습니다.",
+    STEP_IMAGE_NOT_FOUND: "해당 imageId에 대한 이미지가 존재하지 않습니다.",
+    AUTH_KAKAO_CODE_MISSING: "카카오 인가 코드가 없습니다.",
+    AUTH_KAKAO_FAILED: "카카오 로그인 인증에 실패했습니다.",
+    AUTH_TOKEN_INVALID: "유효하지 않거나 만료된 토큰입니다.",
+    AUTH_UNAUTHORIZED: "인증 정보가 유효하지 않습니다.",
+    USER_NOT_FOUND: "사용자 정보를 찾을 수 없습니다.",
+    USER_HIGHLIGHT_COLOR_INVALID: "강조 색상 값이 유효하지 않습니다.",
+    INTERNAL_SERVER_ERROR: "서버 오류가 발생했습니다.",
+  }
+};

--- a/controllers/createManual.js
+++ b/controllers/createManual.js
@@ -1,13 +1,14 @@
 import Manual from "../models/Manual.js";
 import { v4 as uuidv4 } from "uuid";
 import dayjs from "dayjs";
+import { MESSAGES } from "../config/constants.js";
 
 export const createManual = async (req, res, next) => {
   try {
     const { userId } = req.user;
 
     if (!req.files || req.files.length === 0) {
-      const err = new Error("파일이 업로드되지 않았습니다.");
+      const err = new Error(MESSAGES.ERROR.FILE_REQUIRED);
       err.status = 400;
 
       return next(err);
@@ -15,7 +16,7 @@ export const createManual = async (req, res, next) => {
 
     let texts = req.body.text;
     if (!texts) {
-      const err = new Error("단계별 안내 텍스트가 비어 있습니다.");
+      const err = new Error(MESSAGES.ERROR.STEP_TEXT_REQUIRED);
       err.status = 400;
 
       return next(err);

--- a/controllers/createManual.js
+++ b/controllers/createManual.js
@@ -2,25 +2,21 @@ import Manual from "../models/Manual.js";
 import { v4 as uuidv4 } from "uuid";
 import dayjs from "dayjs";
 import { MESSAGES } from "../config/constants.js";
+import { createError } from "../utils/createError.js";
 
 export const createManual = async (req, res, next) => {
   try {
     const { userId } = req.user;
 
     if (!req.files || req.files.length === 0) {
-      const err = new Error(MESSAGES.ERROR.FILE_REQUIRED);
-      err.status = 400;
-
-      return next(err);
+      return next(createError(MESSAGES.ERROR.FILE_REQUIRED, 400));
     }
 
     let texts = req.body.text;
     if (!texts) {
-      const err = new Error(MESSAGES.ERROR.STEP_TEXT_REQUIRED);
-      err.status = 400;
-
-      return next(err);
+      return next(createError(MESSAGES.ERROR.STEP_TEXT_REQUIRED, 400));
     }
+
     if (!Array.isArray(texts)) texts = [texts];
 
     const today = dayjs().format("YYYYMMDD");

--- a/controllers/deleteManual.js
+++ b/controllers/deleteManual.js
@@ -1,4 +1,5 @@
 import Manual from "../models/Manual.js";
+import { MESSAGES } from "../config/constants.js";
 
 export const deleteManual = async (req, res, next) => {
   try {
@@ -7,7 +8,7 @@ export const deleteManual = async (req, res, next) => {
     const manual = await Manual.findOne({ manualId });
 
     if (!manual) {
-      const err = new Error("해당 매뉴얼을 찾을 수 없습니다.");
+      const err = new Error(MESSAGES.ERROR.MANUAL_NOT_FOUND);
       err.status = 404;
 
       return next(err);
@@ -18,7 +19,7 @@ export const deleteManual = async (req, res, next) => {
     res.json({
       deleted: true,
       manualId,
-      message: "해당 매뉴얼이 삭제되었습니다.",
+      message: MESSAGES.SUCCESS.MANUAL_DELETE,
     });
   } catch (err) {
     next(err);

--- a/controllers/deleteManual.js
+++ b/controllers/deleteManual.js
@@ -1,17 +1,14 @@
 import Manual from "../models/Manual.js";
 import { MESSAGES } from "../config/constants.js";
+import { createError } from "../utils/createError.js";
 
 export const deleteManual = async (req, res, next) => {
   try {
     const { manualId } = req.params;
 
     const manual = await Manual.findOne({ manualId });
-
     if (!manual) {
-      const err = new Error(MESSAGES.ERROR.MANUAL_NOT_FOUND);
-      err.status = 404;
-
-      return next(err);
+      return next(createError(MESSAGES.ERROR.MANUAL_NOT_FOUND, 404));
     }
 
     await Manual.deleteOne({ manualId });

--- a/controllers/getManual.js
+++ b/controllers/getManual.js
@@ -1,5 +1,6 @@
 import Manual from "../models/Manual.js";
 import { MESSAGES } from "../config/constants.js";
+import { createError } from "../utils/createError.js";
 
 export const getManual = async (req, res, next) => {
   try {
@@ -7,10 +8,7 @@ export const getManual = async (req, res, next) => {
 
     const manual = await Manual.findOne({ manualId });
     if (!manual) {
-      const err = new Error(MESSAGES.ERROR.MANUAL_NOT_FOUND);
-      err.status = 404;
-
-      return next(err);
+      return next(createError(MESSAGES.ERROR.MANUAL_NOT_FOUND, 404));
     }
 
     res.json({

--- a/controllers/getManual.js
+++ b/controllers/getManual.js
@@ -1,4 +1,5 @@
 import Manual from "../models/Manual.js";
+import { MESSAGES } from "../config/constants.js";
 
 export const getManual = async (req, res, next) => {
   try {
@@ -6,7 +7,7 @@ export const getManual = async (req, res, next) => {
 
     const manual = await Manual.findOne({ manualId });
     if (!manual) {
-      const err = new Error("해당 manualId에 대한 매뉴얼이 존재하지 않습니다.");
+      const err = new Error(MESSAGES.ERROR.MANUAL_NOT_FOUND);
       err.status = 404;
 
       return next(err);
@@ -14,7 +15,7 @@ export const getManual = async (req, res, next) => {
 
     res.json({
       success: true,
-      message: "매뉴얼을 성공적으로 조회했습니다.",
+      message: MESSAGES.SUCCESS.MANUAL_GET,
       data: {
         manualId: manual.manualId,
         name: manual.name,

--- a/controllers/kakaoAuthController.js
+++ b/controllers/kakaoAuthController.js
@@ -3,6 +3,7 @@ import jwt from "jsonwebtoken";
 import { v4 as uuidv4 } from "uuid";
 import User from "../models/User.js";
 import { MESSAGES } from "../config/constants.js";
+import { createError } from "../utils/createError.js";
 
 const JWT_SECRET = env.JWT_SECRET;
 const JWT_EXPIRES_IN = "1h";
@@ -11,10 +12,7 @@ export const kakaoLogin = async (req, res, next) => {
   try {
     const { code } = req.body;
     if (!code) {
-      const err = new Error(MESSAGES.ERROR.AUTH_KAKAO_CODE_MISSING);
-      err.status = 400;
-
-      return next(err);
+      return next(createError(MESSAGES.ERROR.AUTH_KAKAO_CODE_MISSING, 404));
     }
 
     const tokenRes = await fetch("https://kauth.kakao.com/oauth/token", {
@@ -31,10 +29,7 @@ export const kakaoLogin = async (req, res, next) => {
     const tokenData = await tokenRes.json();
     const { access_token, refresh_token } = tokenData;
     if (!access_token) {
-      const err = new Error(MESSAGES.ERROR.AUTH_KAKAO_FAILED);
-      err.status = 401;
-
-      return next(err);
+      return next(createError(MESSAGES.ERROR.AUTH_KAKAO_FAILED, 401));
     }
 
     const userRes = await fetch("https://kapi.kakao.com/v2/user/me", {
@@ -101,18 +96,12 @@ export const refreshToken = async (req, res, next) => {
   try {
     const refreshToken = req.cookies.refreshToken;
     if (!refreshToken) {
-      const err = new Error(MESSAGES.ERROR.AUTH_TOKEN_INVALID);
-      err.status = 401;
-
-      return next(err);
+      return next(createError(MESSAGES.ERROR.AUTH_TOKEN_INVALID, 401));
     }
 
     const user = await User.findOne({ refreshToken });
     if (!user) {
-      const err = new Error(MESSAGES.ERROR.AUTH_TOKEN_INVALID);
-      err.status = 401;
-
-      return next(err);
+      return next(createError(MESSAGES.ERROR.AUTH_TOKEN_INVALID, 401));
     }
 
     const newAccessToken = jwt.sign(

--- a/controllers/kakaoAuthController.js
+++ b/controllers/kakaoAuthController.js
@@ -1,12 +1,9 @@
 import env from "../config/env.js";
-import jwt from "jsonwebtoken";
 import { v4 as uuidv4 } from "uuid";
 import User from "../models/User.js";
 import { MESSAGES } from "../config/constants.js";
 import { createError } from "../utils/createError.js";
-
-const JWT_SECRET = env.JWT_SECRET;
-const JWT_EXPIRES_IN = "1h";
+import { generateAccessToken } from "../utils/jwtUtil.js";
 
 export const kakaoLogin = async (req, res, next) => {
   try {
@@ -62,11 +59,10 @@ export const kakaoLogin = async (req, res, next) => {
       await user.save();
     }
 
-    const jwtAccessToken = jwt.sign(
-      { userId: user.userId, kakaoId: user.kakaoId },
-      JWT_SECRET,
-      { expiresIn: JWT_EXPIRES_IN },
-    );
+    const jwtAccessToken = generateAccessToken({
+      userId: user.userId,
+      kakaoId: user.kakaoId,
+    });
 
     res.cookie("refreshToken", refreshToken, {
       httpOnly: true,
@@ -104,11 +100,10 @@ export const refreshToken = async (req, res, next) => {
       return next(createError(MESSAGES.ERROR.AUTH_TOKEN_INVALID, 401));
     }
 
-    const newAccessToken = jwt.sign(
-      { userId: user.userId, kakaoId: user.kakaoId },
-      JWT_SECRET,
-      { expiresIn: JWT_EXPIRES_IN },
-    );
+    const newAccessToken = generateAccessToken({
+      userId: user.userId,
+      kakaoId: user.kakaoId,
+    });
 
     res.status(200).json({
       success: true,

--- a/controllers/kakaoAuthController.js
+++ b/controllers/kakaoAuthController.js
@@ -2,6 +2,7 @@ import env from "../config/env.js";
 import jwt from "jsonwebtoken";
 import { v4 as uuidv4 } from "uuid";
 import User from "../models/User.js";
+import { MESSAGES } from "../config/constants.js";
 
 const JWT_SECRET = env.JWT_SECRET;
 const JWT_EXPIRES_IN = "1h";
@@ -10,7 +11,7 @@ export const kakaoLogin = async (req, res, next) => {
   try {
     const { code } = req.body;
     if (!code) {
-      const err = new Error("카카오 인가 코드가 없습니다.");
+      const err = new Error(MESSAGES.ERROR.AUTH_KAKAO_CODE_MISSING);
       err.status = 400;
 
       return next(err);
@@ -30,7 +31,7 @@ export const kakaoLogin = async (req, res, next) => {
     const tokenData = await tokenRes.json();
     const { access_token, refresh_token } = tokenData;
     if (!access_token) {
-      const err = new Error("카카오 로그인 인증에 실패했습니다.");
+      const err = new Error(MESSAGES.ERROR.AUTH_KAKAO_FAILED);
       err.status = 401;
 
       return next(err);
@@ -82,7 +83,7 @@ export const kakaoLogin = async (req, res, next) => {
 
     res.status(200).json({
       success: true,
-      message: "로그인 성공 및 회원가입이 완료되었습니다.",
+      message: MESSAGES.SUCCESS.AUTH_LOGIN,
       token: jwtAccessToken,
       user: {
         userId: user.userId,
@@ -100,7 +101,7 @@ export const refreshToken = async (req, res, next) => {
   try {
     const refreshToken = req.cookies.refreshToken;
     if (!refreshToken) {
-      const err = new Error("유효하지 않거나 만료된 토큰입니다.");
+      const err = new Error(MESSAGES.ERROR.AUTH_TOKEN_INVALID);
       err.status = 401;
 
       return next(err);
@@ -108,7 +109,7 @@ export const refreshToken = async (req, res, next) => {
 
     const user = await User.findOne({ refreshToken });
     if (!user) {
-      const err = new Error("유효하지 않거나 만료된 토큰입니다.");
+      const err = new Error(MESSAGES.ERROR.AUTH_TOKEN_INVALID);
       err.status = 401;
 
       return next(err);
@@ -144,7 +145,7 @@ export const kakaoLogout = async (req, res, next) => {
 
     res.json({
       success: true,
-      message: "성공적으로 로그아웃되었습니다.",
+      message: MESSAGES.SUCCESS.AUTH_LOGOUT,
     });
   } catch (err) {
     next(err);

--- a/controllers/s3UploadController.js
+++ b/controllers/s3UploadController.js
@@ -7,7 +7,7 @@ export const uploadImage = (req, res) => {
 
   const uploadedImageUrls = req.files.map((file) => file.location);
 
-  res.status(200).json({
+  res.json({
     message: MESSAGES.SUCCESS.IMAGE_UPLOAD,
     imageUrl: uploadedImageUrls,
   });

--- a/controllers/s3UploadController.js
+++ b/controllers/s3UploadController.js
@@ -1,12 +1,14 @@
+import { MESSAGES } from "../config/constants.js";
+
 export const uploadImage = (req, res) => {
   if (!req.files || req.files.length === 0) {
-    return res.status(400).json({ message: "파일이 업로드되지 않았습니다." });
+    return res.status(400).json({ message: MESSAGES.ERROR.FILE_REQUIRED });
   }
 
   const uploadedImageUrls = req.files.map((file) => file.location);
 
   res.status(200).json({
-    message: "이미지 업로드가 완료되었습니다.",
+    message: MESSAGES.SUCCESS.IMAGE_UPLOAD,
     imageUrl: uploadedImageUrls,
   });
 };

--- a/controllers/updateManualName.js
+++ b/controllers/updateManualName.js
@@ -1,4 +1,5 @@
 import Manual from "../models/Manual.js";
+import { MESSAGES } from "../config/constants.js";
 
 export const updateManualName = async (req, res, next) => {
   try {
@@ -6,7 +7,7 @@ export const updateManualName = async (req, res, next) => {
     const { name } = req.body;
 
     if (!name) {
-      const err = new Error("수정할 제목이 없습니다.");
+      const err = new Error(MESSAGES.ERROR.MANUAL_NAME_REQUIRED);
       err.status = 400;
 
       return next(err);
@@ -19,7 +20,7 @@ export const updateManualName = async (req, res, next) => {
     );
 
     if (!manual) {
-      const err = new Error("해당 manualId에 대한 매뉴얼이 존재하지 않습니다.");
+      const err = new Error(MESSAGES.ERROR.MANUAL_NOT_FOUND);
       err.status = 404;
 
       return next(err);

--- a/controllers/updateManualName.js
+++ b/controllers/updateManualName.js
@@ -1,5 +1,6 @@
 import Manual from "../models/Manual.js";
 import { MESSAGES } from "../config/constants.js";
+import { createError } from "../utils/createError.js";
 
 export const updateManualName = async (req, res, next) => {
   try {
@@ -7,10 +8,7 @@ export const updateManualName = async (req, res, next) => {
     const { name } = req.body;
 
     if (!name) {
-      const err = new Error(MESSAGES.ERROR.MANUAL_NAME_REQUIRED);
-      err.status = 400;
-
-      return next(err);
+      return next(createError(MESSAGES.ERROR.MANUAL_NAME_REQUIRED, 400));
     }
 
     const manual = await Manual.findOneAndUpdate(
@@ -20,10 +18,7 @@ export const updateManualName = async (req, res, next) => {
     );
 
     if (!manual) {
-      const err = new Error(MESSAGES.ERROR.MANUAL_NOT_FOUND);
-      err.status = 404;
-
-      return next(err);
+      return next(createError(MESSAGES.ERROR.MANUAL_NOT_FOUND, 404));
     }
 
     res.json({

--- a/controllers/updateManualStepText.js
+++ b/controllers/updateManualStepText.js
@@ -1,5 +1,6 @@
 import Manual from "../models/Manual.js";
 import { MESSAGES } from "../config/constants.js";
+import { createError } from "../utils/createError.js";
 
 export const updateStepText = async (req, res, next) => {
   try {
@@ -7,26 +8,17 @@ export const updateStepText = async (req, res, next) => {
     const { text } = req.body;
 
     if (!text || typeof text !== "string") {
-      const err = new Error(MESSAGES.ERROR.STEP_TEXT_INVALID);
-      err.status = 400;
-
-      return next(err);
+      return next(createError(MESSAGES.ERROR.STEP_TEXT_INVALID, 400));
     }
 
     const manual = await Manual.findOne({ manualId });
     if (!manual) {
-      const err = new Error(MESSAGES.ERROR.MANUAL_NOT_FOUND);
-      err.status = 404;
-
-      return next(err);
+      return next(createError(MESSAGES.ERROR.MANUAL_NOT_FOUND, 404));
     }
 
     const step = manual.steps.find((step) => step.imageId === imageId);
     if (!step) {
-      const err = new Error(MESSAGES.ERROR.STEP_IMAGE_NOT_FOUND);
-      err.status = 404;
-
-      return next(err);
+      return next(createErro(MESSAGES.ERROR.STEP_IMAGE_NOT_FOUND, 404));
     }
 
     step.text = text;

--- a/controllers/updateManualStepText.js
+++ b/controllers/updateManualStepText.js
@@ -18,7 +18,7 @@ export const updateStepText = async (req, res, next) => {
 
     const step = manual.steps.find((step) => step.imageId === imageId);
     if (!step) {
-      return next(createErro(MESSAGES.ERROR.STEP_IMAGE_NOT_FOUND, 404));
+      return next(createError(MESSAGES.ERROR.STEP_IMAGE_NOT_FOUND, 404));
     }
 
     step.text = text;

--- a/controllers/updateManualStepText.js
+++ b/controllers/updateManualStepText.js
@@ -1,4 +1,5 @@
 import Manual from "../models/Manual.js";
+import { MESSAGES } from "../config/constants.js";
 
 export const updateStepText = async (req, res, next) => {
   try {
@@ -6,7 +7,7 @@ export const updateStepText = async (req, res, next) => {
     const { text } = req.body;
 
     if (!text || typeof text !== "string") {
-      const err = new Error("수정할 텍스트가 유효하지 않습니다.");
+      const err = new Error(MESSAGES.ERROR.STEP_TEXT_INVALID);
       err.status = 400;
 
       return next(err);
@@ -14,7 +15,7 @@ export const updateStepText = async (req, res, next) => {
 
     const manual = await Manual.findOne({ manualId });
     if (!manual) {
-      const err = new Error("해당 manualId에 대한 매뉴얼이 존재하지 않습니다.");
+      const err = new Error(MESSAGES.ERROR.MANUAL_NOT_FOUND);
       err.status = 404;
 
       return next(err);
@@ -22,7 +23,7 @@ export const updateStepText = async (req, res, next) => {
 
     const step = manual.steps.find((step) => step.imageId === imageId);
     if (!step) {
-      const err = new Error("해당 imageId에 대한 이미지가 존재하지 않습니다.");
+      const err = new Error(MESSAGES.ERROR.STEP_IMAGE_NOT_FOUND);
       err.status = 404;
 
       return next(err);

--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -1,5 +1,6 @@
 import User from "../models/User.js";
 import env from "../config/env.js";
+import { MESSAGES } from "../config/constants.js";
 
 export const getUserMe = async (req, res, next) => {
   try {
@@ -8,7 +9,7 @@ export const getUserMe = async (req, res, next) => {
     const user = await User.findOne({ userId });
 
     if (!user) {
-      const err = new Error("사용자 정보를 찾을 수 없습니다.");
+      const err = new Error(MESSAGES.ERROR.USER_NOT_FOUND);
       err.status = 404;
       return next(err);
     }
@@ -33,7 +34,7 @@ export const deleteUserMe = async (req, res, next) => {
 
     const user = await User.findOneAndDelete({ userId });
     if (!user) {
-      const err = new Error("사용자 정보를 찾을 수 없습니다.");
+      const err = new Error(MESSAGES.ERROR.USER_NOT_FOUND);
       err.status = 404;
 
       return next(err);
@@ -48,7 +49,7 @@ export const deleteUserMe = async (req, res, next) => {
 
     res.json({
       success: true,
-      message: "회원 탈퇴가 완료되었습니다."
+      message: MESSAGES.SUCCESS.AUTH_DELETE,
     });
   } catch (err) {
     next(err);
@@ -61,7 +62,7 @@ export const updateHighlightColor = async (req, res, next) => {
     const { highlightColor } = req.body;
 
     if (!highlightColor || typeof highlightColor !== "string") {
-      const err = new Error("highlightColor 값이 유효하지 않습니다.");
+      const err = new Error(MESSAGES.ERROR.USER_HIGHLIGHT_COLOR_INVALID);
       err.status = 400;
 
       return next(err);
@@ -74,7 +75,7 @@ export const updateHighlightColor = async (req, res, next) => {
     )
 
     if (!user) {
-      const err = new Error("사용자 정보를 찾을 수 없습니다.");
+      const err = new Error(MESSAGES.ERROR.USER_NOT_FOUND);
       err.status = 404;
 
       return next(err);

--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -1,6 +1,7 @@
 import User from "../models/User.js";
 import env from "../config/env.js";
 import { MESSAGES } from "../config/constants.js";
+import { createError } from "../utils/createError.js";
 
 export const getUserMe = async (req, res, next) => {
   try {
@@ -9,9 +10,7 @@ export const getUserMe = async (req, res, next) => {
     const user = await User.findOne({ userId });
 
     if (!user) {
-      const err = new Error(MESSAGES.ERROR.USER_NOT_FOUND);
-      err.status = 404;
-      return next(err);
+      return next(createError(MESSAGES.ERROR.USER_NOT_FOUND, 404));
     }
 
     res.status(200).json({
@@ -34,10 +33,7 @@ export const deleteUserMe = async (req, res, next) => {
 
     const user = await User.findOneAndDelete({ userId });
     if (!user) {
-      const err = new Error(MESSAGES.ERROR.USER_NOT_FOUND);
-      err.status = 404;
-
-      return next(err);
+      return next(createError(MESSAGES.ERROR.USER_NOT_FOUND, 404));
     }
 
     res.clearCookie("refreshToken", {
@@ -62,10 +58,7 @@ export const updateHighlightColor = async (req, res, next) => {
     const { highlightColor } = req.body;
 
     if (!highlightColor || typeof highlightColor !== "string") {
-      const err = new Error(MESSAGES.ERROR.USER_HIGHLIGHT_COLOR_INVALID);
-      err.status = 400;
-
-      return next(err);
+      return next(createError(MESSAGES.ERROR.USER_HIGHLIGHT_COLOR_INVALID, 400));
     }
 
     const user = await User.findOneAndUpdate(
@@ -75,10 +68,7 @@ export const updateHighlightColor = async (req, res, next) => {
     )
 
     if (!user) {
-      const err = new Error(MESSAGES.ERROR.USER_NOT_FOUND);
-      err.status = 404;
-
-      return next(err);
+      return next(createError(MESSAGES.ERROR.USER_NOT_FOUND, 404));
     }
 
     res.json({

--- a/middlewares/errorHandler.js
+++ b/middlewares/errorHandler.js
@@ -1,7 +1,10 @@
+import { MESSAGES } from "../config/constants.js";
+
 export default function errorHandler(err, req, res, next) {
   const status = err.status || 500;
+
   res.status(status).json({
     success: false,
-    message: err.message || "서버 오류가 발생했습니다.",
+    message: err.message || MESSAGES.ERROR.INTERNAL_SERVER_ERROR,
   });
 }

--- a/middlewares/verifyToken.js
+++ b/middlewares/verifyToken.js
@@ -1,9 +1,7 @@
-import env from "../config/env.js";
-import jwt from "jsonwebtoken";
 import { MESSAGES } from "../config/constants.js";
 import { createError } from "../utils/createError.js";
+import { verifyAccessToken } from "../utils/jwtUtil.js";
 
-const JWT_SECRET = env.JWT_SECRET;
 
 export const verifyToken = (req, res, next) => {
   const authHeader = req.headers.authorization;
@@ -15,7 +13,7 @@ export const verifyToken = (req, res, next) => {
   const token = authHeader.split(" ")[1];
 
   try {
-    const decoded = jwt.verify(token, JWT_SECRET);
+    const decoded = verifyAccessToken(token);
     req.user = decoded;
 
     next();

--- a/middlewares/verifyToken.js
+++ b/middlewares/verifyToken.js
@@ -1,5 +1,6 @@
 import env from "../config/env.js";
 import jwt from "jsonwebtoken";
+import { MESSAGES } from "../config/constants.js";
 
 const JWT_SECRET = env.JWT_SECRET;
 
@@ -7,7 +8,7 @@ export const verifyToken = (req, res, next) => {
   const authHeader = req.headers.authorization;
 
   if (!authHeader || !authHeader.startsWith("Bearer ")) {
-    const err = new Error("인증 정보가 유효하지 않습니다.");
+    const err = new Error(MESSAGES.ERROR.AUTH_UNAUTHORIZED);
     err.status = 401;
 
     return next(err);
@@ -18,10 +19,9 @@ export const verifyToken = (req, res, next) => {
   try {
     const decoded = jwt.verify(token, JWT_SECRET);
     req.user = decoded;
+
     next();
   } catch (err) {
-    err.status = 401;
-    err.message = "인증 정보가 유효하지 않습니다.";
     next(err);
   }
 };

--- a/middlewares/verifyToken.js
+++ b/middlewares/verifyToken.js
@@ -1,6 +1,7 @@
 import env from "../config/env.js";
 import jwt from "jsonwebtoken";
 import { MESSAGES } from "../config/constants.js";
+import { createError } from "../utils/createError.js";
 
 const JWT_SECRET = env.JWT_SECRET;
 
@@ -8,10 +9,7 @@ export const verifyToken = (req, res, next) => {
   const authHeader = req.headers.authorization;
 
   if (!authHeader || !authHeader.startsWith("Bearer ")) {
-    const err = new Error(MESSAGES.ERROR.AUTH_UNAUTHORIZED);
-    err.status = 401;
-
-    return next(err);
+    return next(createError(MESSAGES.ERROR.AUTH_UNAUTHORIZED, 401));
   }
 
   const token = authHeader.split(" ")[1];

--- a/models/Manual.js
+++ b/models/Manual.js
@@ -37,18 +37,6 @@ const manualSchema = new mongoose.Schema(
       required: true,
     },
     steps: [stepSchema],
-    sharedToken: {
-      type: String,
-      default: null,
-    },
-    sharedAt: {
-      type: Date,
-      default: null,
-    },
-    shareUrl: {
-      type: String,
-      default: null,
-    },
   },
   {
     timestamps: true,

--- a/utils/createError.js
+++ b/utils/createError.js
@@ -1,0 +1,6 @@
+export const createError = (message, status = 500) => {
+  const err = new Error(message);
+  err.status = status;
+
+  return err;
+};

--- a/utils/jwtUtil.js
+++ b/utils/jwtUtil.js
@@ -1,0 +1,13 @@
+import jwt from "jsonwebtoken";
+import env from "../config/env.js";
+
+const JWT_SECRET = env.JWT_SECRET;
+const JWT_EXPIRES_IN = "1h";
+
+export const generateAccessToken = (payload) => {
+  return jwt.sign(payload, JWT_SECRET, { expiresIn: JWT_EXPIRES_IN });
+};
+
+export const verifyAccessToken = (token) => {
+  return jwt.verify(token, JWT_SECRET);
+};


### PR DESCRIPTION
## #️⃣ Issue Number #24

## 📝 세부 내용

- JWT 관련 로직을 utils/jwt.js로 분리하여 재사용성과 가독성을 개선했습니다.
- 에러/성공 메시지를 config/constants.js에 상수로 분리했습니다.
- 반복되는 에러 핸들링 로직을 createError 유틸 함수로 통일했습니다.
- 더 이상 사용되지 않는 스키마 필드를 제거했습니다.

## ✅ 체크리스트

- [x] 커밋 메시지 컨벤션을 지켰습니다 (`feat:`, `fix:`, `chore:` 등).
- [x] 관련 기능/버그에 대해 테스트를 완료했습니다.
- [x] 코드 스타일 가이드에 맞게 작성했습니다.
