### PR TITLE
fix: 매뉴얼 step 텍스트 필드 기본값을 빈 문자열로 설정 (#29)

### DIFF
--- a/models/Manual.js
+++ b/models/Manual.js
@@ -8,7 +8,7 @@ const stepSchema = new mongoose.Schema(
     },
     text: {
       type: String,
-      required: true,
+      default: "",
     },
     url: {
       type: String,


### PR DESCRIPTION
## #️⃣ Issue Number #29

## 📝 세부 내용

매뉴얼에서 그림 또는 빈 영역을 클릭할 때, 해당 step의 text 값이 빈 문자열("")로 전달되는 경우가 있습니다.

그러나 기존 백엔드 스키마에서는 text 필드에 required: true가 설정되어 있어, 빈 값이 저장되지 않고 오류가 발생했습니다.

이를 해결하기 위해 required 옵션을 제거하고, 기본값을 ""로 설정하여 빈 문자열도 정상적으로 저장되도록 수정했습니다.

## ✅ 체크리스트

- [x] 커밋 메시지 컨벤션을 지켰습니다 (`feat:`, `fix:`, `chore:` 등).
- [x] 관련 기능/버그에 대해 테스트를 완료했습니다.
- [x] 코드 스타일 가이드에 맞게 작성했습니다.
