### PR TITLE
fix: step 생성 시 빈 텍스트도 허용하도록 검증 조건 제거 (#31)

### DIFF
--- a/controllers/createManual.js
+++ b/controllers/createManual.js
@@ -13,10 +13,6 @@ export const createManual = async (req, res, next) => {
     }
 
     let texts = req.body.text;
-    if (!texts) {
-      return next(createError(MESSAGES.ERROR.STEP_TEXT_REQUIRED, 400));
-    }
-
     if (!Array.isArray(texts)) texts = [texts];
 
     const today = dayjs().format("YYYYMMDD");


### PR DESCRIPTION
## #️⃣ Issue Number #31

## 📝 세부 내용

- 사용자가 특정 영역을 클릭하면 해당 시점에 step이 자동 저장되도록 구성되어 있습니다.
이때 text는 빈 문자열 하나만 전달될 수 있어, 기존의 !texts 조건을 제거하여 해당 케이스도 저장되도록 수정했습니다.

## ✅ 체크리스트

- [x] 커밋 메시지 컨벤션을 지켰습니다 (`feat:`, `fix:`, `chore:` 등).
- [x] 관련 기능/버그에 대해 테스트를 완료했습니다.
- [x] 코드 스타일 가이드에 맞게 작성했습니다.
